### PR TITLE
Changed "esnext" target to es6 for compatibility with current NodeJS 

### DIFF
--- a/part-1/Makefile
+++ b/part-1/Makefile
@@ -15,7 +15,7 @@ test.s: compiler.js
 	node compiler.js > test.s
 
 %.js: %.ts
-	tsc --strict --module commonjs --target esnext $<
+	tsc --strict --module commonjs --target es6 $<
 
 clean: phony
 	rm *.exe *.s *.js

--- a/part-2/Makefile
+++ b/part-2/Makefile
@@ -17,7 +17,7 @@ test: build/test.exe phony
 	node $< > $@
 
 build/%.js: %.ts $(SOURCES) Makefile
-	tsc --strict --outdir build --module commonjs --target esnext $<
+	tsc --strict --outdir build --module commonjs --target es6 $<
 
 clean: phony
 	rm -fr build


### PR DESCRIPTION
There was an error compiling the make file for node 10.19.0 from TypeScript 4.4.4. This fixes that.