### PR TITLE
Introduce minimal web playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Install GCC toolchain that targets 32-bit ARM:
 -->
 
 
+## In the browser
+
+Minimal browser playground is available as well.
+
+```bash
+cd part-2
+make web/build.js
+open web/index.html
+```
+
 ## Contribution
 
 You are welcome to contribute your version of the book's compiler.

--- a/part-2/Makefile
+++ b/part-2/Makefile
@@ -19,5 +19,8 @@ test: build/test.exe phony
 build/%.js: %.ts $(SOURCES) Makefile
 	tsc --strict --outdir build --module commonjs --target es6 $<
 
+web/build.js: $(SOURCES) Makefile
+	tsc --strict --outfile web/build.js --module amd --target es6 $(SOURCES)
+
 clean: phony
 	rm -fr build

--- a/part-2/code-generator.ts
+++ b/part-2/code-generator.ts
@@ -577,4 +577,12 @@ class CodeGeneratorDynamicTyping implements Visitor<void> {
   }
 }
 
-export { CodeGenerator, CodeGeneratorDynamicTyping }
+function setEmitFunction(emitFunction: (input: string) => void) {
+  emit = emitFunction
+}
+
+function reset() {
+  Label.counter = 0;
+}
+
+export { CodeGenerator, CodeGeneratorDynamicTyping, setEmitFunction, reset }

--- a/part-2/web/index.html
+++ b/part-2/web/index.html
@@ -1,0 +1,87 @@
+<html>
+  <head>
+    <title>Playground for Compiling to Assembly from Scratch</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        font-family: Georgia, "Times New Roman", Times, serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      h1 {
+        font-weight: 100;
+      }
+      textarea {
+        font-size: 14px;
+        font-family: monospace;
+      }
+    </style>
+    <script src="https://requirejs.org/docs/release/2.3.6/minified/require.js"></script>
+    <script src="build.js"></script>
+    <script>
+      function compile() {
+        requirejs(
+          ["parser", "code-generator"],
+          function ({ parser }, { CodeGenerator, setEmitFunction, reset }) {
+            reset();
+            try {
+              const source = document.getElementById("input").value;
+              const ast = parser.parseStringToCompletion(source);
+
+              let output = "";
+              setEmitFunction((input) => {
+                output += input + "\n";
+              });
+
+              const codeGenerator = new CodeGenerator();
+              ast.visit(codeGenerator);
+
+              renderOutput(output);
+            } catch (e) {
+              renderOutput(e.toString());
+            }
+          }
+        );
+      }
+
+      function renderOutput(code) {
+        document.getElementById("output").value = code.trim();
+      }
+
+      compile();
+    </script>
+  </head>
+  <body>
+    <div style="display: flex; flex-flow: column; height: 100%; padding: 1em">
+      <div>
+        <h1 style="margin-top: 0">
+          Playground for
+          <a
+            href="https://github.com/keleshev/compiling-to-assembly-from-scratch"
+            >Compiling to Assembly from Scratch</a
+          >
+        </h1>
+      </div>
+      <div style="display: flex; flex-direction: row; flex-grow: 1">
+        <textarea id="input" style="flex-grow: 1" oninput="compile()">
+function factorial(n: number): number {
+  if (n == 0) {
+    return 1;
+  } else {
+    return n * factorial(n - 1);
+  }
+}
+
+function main() {
+  assert(factorial(5) == 120);
+  return 0;
+}</textarea
+        >
+        <textarea id="output" style="flex-grow: 1; margin-left: 1em"></textarea>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Hey :-)

As I'm writing my own toy compiler, I wanted to compare the output with the compiler from your book. I am a big fan of https://godbolt.org playground and thought it would be nice to have a playground for this compiler as well.

It is quite minimal and does not introduce any new dependencies. If you decide to land this, I think you can easily setup it on GitHub Pages by pointing it to `./part-2/web/index.html`.

Here is how it looks:

<img width="1152" alt="Screenshot 2023-03-09 at 19 00 12" src="https://user-images.githubusercontent.com/794591/224116755-5b1f041b-afa0-4370-8ab7-d7b107c6dadd.png">
